### PR TITLE
fix: drop locks to make signal handler safe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,10 @@ once_cell = "1.19.0"
 pin-project = "1.1.5"
 
 [dev-dependencies]
-monoio = "0.2.3"
-tokio = { version = "1.38.0", features = ["macros"] }
+# the sync feature is necessary as in our test, `waker.wake()` will be invoked
+# by a thread other than the runtime thread, such a `wake()` will ONLY work if
+# the `sync` feature is enabled.
+monoio ={ version =  "0.2.3", features = ["sync"] }
+tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread", "time"] }
+glommio = "0.9.0"
+futures = "0.3.30"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,24 +10,54 @@ use nix::sys::signal::SigHandler;
 use nix::sys::signal::SigSet;
 use once_cell::sync::Lazy;
 use pin_project::pin_project;
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::cell::UnsafeCell;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::RwLock;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::task::Context;
 use std::task::Poll;
 
-static REGISTERED_EVENTS: Lazy<RwLock<HashMap<Signal, Event>>> =
-    Lazy::new(|| RwLock::new(HashMap::new()));
+#[derive(Debug)]
+struct UnsafeCellOptEvent(UnsafeCell<Option<Event>>);
+
+unsafe impl Send for UnsafeCellOptEvent {}
+unsafe impl Sync for UnsafeCellOptEvent {}
+
+impl UnsafeCellOptEvent {
+    fn new() -> Self {
+        UnsafeCellOptEvent(UnsafeCell::new(None))
+    }
+
+    fn get(&self) -> &Option<Event> {
+        unsafe { &*self.0.get() }
+    }
+
+    fn set(&self, event: Event) {
+        let ptr = self.0.get();
+        unsafe {
+            *ptr = Some(event);
+        }
+    }
+}
+
+static REGISTERED_EVENTS: Lazy<Vec<(AtomicBool, UnsafeCellOptEvent)>> = Lazy::new(|| {
+    let n_signal = nix::libc::SIGRTMAX() as usize;
+    (0..n_signal)
+        .map(|_| (AtomicBool::new(false), UnsafeCellOptEvent::new()))
+        .collect()
+});
 
 extern "C" fn handler(sig_num: c_int) {
-    let signal = Signal::try_from(sig_num).expect("unknown signal");
+    let sig_num = sig_num as usize;
+    debug_assert!(REGISTERED_EVENTS[sig_num].0.load(Ordering::Relaxed));
     REGISTERED_EVENTS
-        .read()
-        .unwrap()
-        .get(&signal)
-        .expect("should be registered")
+        .get(sig_num)
+        .expect("all the signal numbers should be smaller than libc::SIGRTMAX")
+        .1
+        .get()
+        .as_ref()
+        .expect("event should be set")
         .notify(usize::MAX);
 }
 
@@ -59,22 +89,53 @@ pub struct SignalFut {
 impl SignalFut {
     /// Create a `SignalFut` for `signal`.
     pub fn new(signal: Signal) -> SignalFut {
-        let mut registered_events_write_guard = REGISTERED_EVENTS.write().unwrap();
-        match registered_events_write_guard.entry(signal) {
-            Entry::Occupied(event) => {
-                let listener = event.get().listen();
-                SignalFut { signal, listener }
-            }
-            Entry::Vacant(key) => {
-                let event = Event::new();
-                let listener = event.listen();
+        let sig_num = signal as usize;
+        let has_event = REGISTERED_EVENTS
+            .get(sig_num)
+            .expect("all the signal numbers should be smaller than libc::SIGRTMAX")
+            .0
+            .load(Ordering::Relaxed);
 
-                let sig_handler = SigHandler::Handler(handler);
-                let sig_action = SigAction::new(sig_handler, SaFlags::empty(), SigSet::empty());
-                // SAFETY: let's just assume it is safe
-                unsafe { sigaction(signal, &sig_action).unwrap() };
-                key.insert(event);
-                SignalFut { signal, listener }
+        if has_event {
+            let listener = REGISTERED_EVENTS
+                .get(sig_num)
+                .expect("")
+                .1
+                .get()
+                .as_ref()
+                .expect("")
+                .listen();
+            SignalFut { signal, listener }
+        } else {
+            // do the job
+            let event = Event::new();
+            let listener = event.listen();
+            REGISTERED_EVENTS.get(sig_num).expect("").1.set(event);
+            let sig_handler = SigHandler::Handler(handler);
+            let sig_action = SigAction::new(sig_handler, SaFlags::empty(), SigSet::empty());
+            // SAFETY: let's just assume it is safe
+            unsafe { sigaction(signal, &sig_action).unwrap() };
+
+            // then race
+            let res = REGISTERED_EVENTS
+                .get(sig_num)
+                .expect("")
+                .0
+                .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed);
+
+            match res {
+                Ok(_) => SignalFut { signal, listener },
+                Err(_) => {
+                    let listener = REGISTERED_EVENTS
+                        .get(sig_num)
+                        .expect("")
+                        .1
+                        .get()
+                        .as_ref()
+                        .expect("")
+                        .listen();
+                    SignalFut { signal, listener }
+                }
             }
         }
     }
@@ -92,4 +153,80 @@ impl Future for SignalFut {
 /// Completes when a “ctrl-c” notification is sent to the process.
 pub async fn ctrl_c() {
     SignalFut::new(Signal::SIGINT).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nix::sys::signal::kill;
+    use nix::unistd::Pid;
+
+    #[monoio::test]
+    async fn sighup_with_monoio() {
+        let fut = SignalFut::new(Signal::SIGHUP);
+        kill(Pid::this(), Signal::SIGHUP).unwrap();
+        fut.await;
+    }
+
+    #[tokio::test]
+    async fn sigint_with_tokio() {
+        let fut = SignalFut::new(Signal::SIGINT);
+        kill(Pid::this(), Signal::SIGINT).unwrap();
+        fut.await;
+    }
+
+    #[test]
+    fn sigquit_with_futures_block_on() {
+        futures::executor::block_on(async move {
+            let fut = SignalFut::new(Signal::SIGQUIT);
+            kill(Pid::this(), Signal::SIGQUIT).unwrap();
+            fut.await;
+        });
+    }
+
+    #[test]
+    fn sigill_with_glommio() {
+        glommio::LocalExecutorBuilder::default()
+            .spawn(|| async {
+                let fut = SignalFut::new(Signal::SIGILL);
+                kill(Pid::this(), Signal::SIGILL).unwrap();
+                fut.await;
+            })
+            .unwrap()
+            .join()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn multiple_futures_with_tokio_select() {
+        let sigint_fut = SignalFut::new(Signal::SIGTERM);
+        let sigquit_fut = SignalFut::new(Signal::SIGABRT);
+        kill(Pid::this(), Signal::SIGTERM).unwrap();
+        tokio::select! {
+            _ = sigint_fut => {},
+            _ = sigquit_fut => {},
+        }
+    }
+
+    #[tokio::test]
+    async fn multiple_tasks_waiting_for_same_signal() {
+        let task1 = async {
+            SignalFut::new(Signal::SIGURG).await;
+        };
+        let task2 = async {
+            SignalFut::new(Signal::SIGURG).await;
+        };
+
+        let handle1 = tokio::spawn(task1);
+        let handle2 = tokio::spawn(task2);
+
+        // sleep for 1 second to ensure that task1 and task2 will be polled for
+        // at least once so that signal handler can be set.
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+        kill(Pid::this(), Signal::SIGURG).unwrap();
+
+        handle1.await.unwrap();
+        handle2.await.unwrap();
+    }
 }


### PR DESCRIPTION
Drop the usage of RwLock so that we can possibly be signal safe.

Well, I can still get deadlocks with this implementation, but let's merge this for now.