### PR TITLE
fix: run event.notify() to a thread so that we are signal safe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 event-listener = "5.3.1"
-nix = { version = "0.29.0", features = ["signal"] }
+nix = { version = "0.29.0", features = ["signal", "fs"] }
 once_cell = "1.19.0"
 pin-project = "1.1.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,12 @@ pin-project = "1.1.5"
 # the sync feature is necessary as in our test, `waker.wake()` will be invoked
 # by a thread other than the runtime thread, such a `wake()` will ONLY work if
 # the `sync` feature is enabled.
-monoio ={ version =  "0.2.3", features = ["sync"] }
+monoio = { version = "0.2.3", features = ["sync"] }
 tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread", "time"] }
 futures = "0.3.30"
+smol = "2.0.0"
+compio = { version = "0.10.0", features = ["macros", "runtime", "time"] }
+async-std = { version = "1.12.0", features = ["attributes"] }
 
 [target.'cfg(target_os="linux")'.dev-dependencies]
 glommio = "0.9.0"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,21 @@
 ## signal-future
 
-Similar to [tokio::signal][link], but can be used with [glommio][g] and [monoio][m].
+A future similar to [tokio::signal::unix::Signal][link], but can be used with:
 
-[link]: https://docs.rs/tokio/latest/tokio/signal/index.html
-[g]: https://github.com/DataDog/glommio
-[m]: https://github.com/bytedance/monoio
+[link]: https://docs.rs/tokio/latest/tokio/signal/unix/struct.Signal.html#
+
+* Tokio
+* async-std
+* futures
+* smol
+* Monoio
+* Glommio
+* Compio
+
+## Supported platforms
+
+Currently, only Linux and macOS are supported. Windows will also be supported in
+the future.
 
 ## Examples
 
@@ -15,18 +26,13 @@ use signal_future::ctrl_c;
 use signal_future::Signal;
 use signal_future::SignalFut;
 
-fn main() {
-    let mut rt = monoio::RuntimeBuilder::<monoio::FusionDriver>::new()
-        .enable_all()
-        .build()
-        .unwrap();
-    rt.block_on(async move {
-        tokio::select! {
-            _ = ctrl_c() => {},
-            _ = SignalFut::new(Signal::SIGQUIT) => {},
-        }
-        println!("Greeting!");
-    });
+#[tokio::main]
+async fn main() {
+    tokio::select! {
+        _ = ctrl_c() => {},
+        _ = SignalFut::new(Signal::SIGQUIT) => {},
+    }
+    println!("Greeting!");
 }
 ```
 
@@ -35,16 +41,25 @@ Let multiple tasks wait for the same signal:
 ```rust,no_run
 use signal_future::ctrl_c;
 
-fn main() {
-    let mut rt = monoio::RuntimeBuilder::<monoio::FusionDriver>::new()
-        .enable_all()
-        .build()
-        .unwrap();
-    rt.block_on(async move {
-        let fut1 = ctrl_c();
-        let fut2 = ctrl_c();
+#[tokio::main]
+async fn main() {
+    let fut1 = ctrl_c();
+    let fut2 = ctrl_c();
 
-        tokio::join!(fut1, fut2);
-    });
+    tokio::join!(fut1, fut2);
 }
 ```
+
+## Signal handler
+
+This crate disposes a signal handler for the signals you want to watch, since
+signal handler is shared by the whole process, don't use other crates that also
+do this, they will clash.
+
+After disposition, the default signal handler will not be reset.
+
+## Helper thread and Signal Safety
+
+This crate creates a helper thread to execute the code that is not signal-safe,
+the signal handler and the helper thread communicate through an OS pipe, the only
+thing that the signal handler does is `write(2)`, which is signal-safe.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,8 +241,7 @@ impl SignalFut {
             // dispose the signal
             let sig_handler = SigHandler::Handler(handler);
             let sig_action = SigAction::new(sig_handler, SaFlags::empty(), SigSet::empty());
-            // SAFETY:
-            // if `event-listener::Event::notify(usize::MAX)` is signal-safe, then it is safe.
+            // SAFETY: the signal handler is safe
             unsafe { sigaction(signal, &sig_action).unwrap() };
 
             // Set the initialized mark

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -491,6 +491,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "linux")] // glommio is Linux-only
     fn multiple_tasks_waiting_for_same_signal_with_glommio() {
         let main_task = async {
             let task1 = SignalFut::new(Signal::SIGINT);

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -29,4 +29,6 @@ pub(crate) fn pipe() -> (OwnedFd, OwnedFd) {
 
     nix::fcntl::fcntl(rx.as_raw_fd(), nix::fcntl::FcntlArg::F_SETFL(rx_flag)).unwrap();
     nix::fcntl::fcntl(tx.as_raw_fd(), nix::fcntl::FcntlArg::F_SETFL(tx_flag)).unwrap();
+
+    (rx, tx)
 }

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -1,9 +1,6 @@
 /// Return a pipe, with `O_CLOEXEC` set.
 use std::os::fd::OwnedFd;
 
-#[cfg(all(unix, not(target_os = "linux")))]
-use nix::unistd::pipe;
-
 /// Return a pipe, with `O_CLOEXEC` set.
 #[cfg(target_os = "linux")]
 pub(crate) fn pipe() -> (OwnedFd, OwnedFd) {

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -1,0 +1,32 @@
+/// Return a pipe, with `O_CLOEXEC` set.
+use std::os::fd::OwnedFd;
+
+#[cfg(all(unix, not(target_os = "linux")))]
+use nix::unistd::pipe;
+
+/// Return a pipe, with `O_CLOEXEC` set.
+#[cfg(target_os = "linux")]
+pub(crate) fn pipe() -> (OwnedFd, OwnedFd) {
+    nix::unistd::pipe2(nix::fcntl::OFlag::O_CLOEXEC).unwrap()
+}
+
+/// Return a pipe, with `O_CLOEXEC` set.
+#[cfg(target_os = "macos")]
+pub(crate) fn pipe() -> (OwnedFd, OwnedFd) {
+    use std::os::fd::AsRawFd;
+
+    let (rx, tx) = nix::unistd::pipe().unwrap();
+    let mut rx_flag = nix::fcntl::OFlag::from_bits(
+        nix::fcntl::fcntl(rx.as_raw_fd(), nix::fcntl::FcntlArg::F_GETFL).unwrap(),
+    )
+    .unwrap();
+    rx_flag.insert(nix::fcntl::OFlag::O_CLOEXEC);
+    let mut tx_flag = nix::fcntl::OFlag::from_bits(
+        nix::fcntl::fcntl(tx.as_raw_fd(), nix::fcntl::FcntlArg::F_GETFL).unwrap(),
+    )
+    .unwrap();
+    tx_flag.insert(nix::fcntl::OFlag::O_CLOEXEC);
+
+    nix::fcntl::fcntl(rx.as_raw_fd(), nix::fcntl::FcntlArg::F_SETFL(rx_flag)).unwrap();
+    nix::fcntl::fcntl(tx.as_raw_fd(), nix::fcntl::FcntlArg::F_SETFL(tx_flag)).unwrap();
+}


### PR DESCRIPTION
## What does this PR do

Move `event.notify()` to a helper thread so that it won't be called in the signal handler, similar to the approach adopted by [ctrlc](https://github.com/Detegr/rust-ctrlc/blob/master/src/platform/unix/mod.rs).

## Why

To solve the signal-safety problem.

Though I am not sure if `event_listener::Event::notify()` is signal-safe, but from my observation, moving it to a dedicated thread indeed fixes the deadlock.

Related: https://github.com/smol-rs/event-listener/issues/141


`pipe2()` is not available on macOS, so CI won't pass, we have to emulate it through `pipe()` and `fcntl()`.