### PR TITLE
chore: rename to signalfut and prepare for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,5 +51,10 @@ jobs:
           toolchain: '${{ env.MSRV }}'
           components: clippy, rustfmt
 
+        # adopted from: 
+        # https://github.com/rust-lang/cargo/issues/5133#issuecomment-1307094647
+      - name: Clear dev deps
+        run: sed -i 's/\[dev-dependencies]/[workaround-avoid-dev-deps]/g' ./signalfut/Cargo.toml
+
       - name: Check build
         run: cargo build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,7 @@ jobs:
         # adopted from: 
         # https://github.com/rust-lang/cargo/issues/5133#issuecomment-1307094647
       - name: Clear dev deps
-        run: |
-          pwd
-          ls -al
-          sed -i 's/\[dev-dependencies]/[workaround-avoid-dev-deps]/g' ./signalfut/Cargo.toml
+        run: sed -i 's/\[dev-dependencies]/[workaround-avoid-dev-deps]/g' Cargo.toml
 
       - name: Check build
         run: cargo build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,10 @@ jobs:
         # adopted from: 
         # https://github.com/rust-lang/cargo/issues/5133#issuecomment-1307094647
       - name: Clear dev deps
-        run: sed -i 's/\[dev-dependencies]/[workaround-avoid-dev-deps]/g' ./signalfut/Cargo.toml
+        run: |
+          pwd
+          ls -al
+          sed -i 's/\[dev-dependencies]/[workaround-avoid-dev-deps]/g' ./signalfut/Cargo.toml
 
       - name: Check build
         run: cargo build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  MSRV: 1.69.0
 
 jobs:
   main:
@@ -31,6 +32,24 @@ jobs:
 
       - name: Check format
         run: cargo fmt --all --check
+
+      - name: Check clippy
+        run: cargo clippy
+
+      - name: Unit tests
+        run: cargo test
+
+  check_msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
+        with: 
+          toolchain: '${{ env.MSRV }}'
+          components: clippy, rustfmt
 
       - name: Check clippy
         run: cargo clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,5 @@ jobs:
           toolchain: '${{ env.MSRV }}'
           components: clippy, rustfmt
 
-      - name: Check clippy
-        run: cargo clippy
-
-      - name: Unit tests
-        run: cargo test
+      - name: Check build
+        run: cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,21 @@
 [package]
-name = "signal_future"
+name = "signalfut"
+description = "A future similar to tokio::signal::unix::Signal, but can be used with all the runtimes"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.69"
+authors = ["SteveLauC <stevelauc@outlook.com>"]
+readme = "README.md"
+license = "Apache-2.0"
+repository = "https://github.com/SteveLauC/signalfut"
+categories = ["asynchronous"]
+keywords = ["signal"]
+
+[package.metadata.docs.rs]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-apple-darwin",
+]
 
 [dependencies]
 event-listener = "5.3.1"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-## signal-future
+# signalfut
+
+[![crates.io](https://img.shields.io/crates/v/signalfut?style=flat-square&logo=rust)](https://crates.io/crates/signalfut)
+[![docs.rs](https://img.shields.io/badge/docs.rs-signalfut-blue?style=flat-square&logo=docs.rs)](https://docs.rs/signalfut)
+[![msrv](https://img.shields.io/badge/msrv-1.69-blue?style=flat-square&logo=rust)](https://www.rust-lang.org)
+[![BUILD](https://github.com/stevelauc/signalfut/workflows/Rust/badge.svg)](https://github.com/stevelauc/signalfut/actions/workflows/ci.yml)
+
 
 A future similar to [tokio::signal::unix::Signal][link], but can be used with:
 
@@ -22,9 +28,9 @@ the future.
 Greet when receive either `SIGINT` or `SIGQUIT`:
 
 ```rust,no_run
-use signal_future::ctrl_c;
-use signal_future::Signal;
-use signal_future::SignalFut;
+use signalfut::ctrl_c;
+use signalfut::Signal;
+use signalfut::SignalFut;
 
 #[tokio::main]
 async fn main() {
@@ -39,7 +45,7 @@ async fn main() {
 Let multiple tasks wait for the same signal:
 
 ```rust,no_run
-use signal_future::ctrl_c;
+use signalfut::ctrl_c;
 
 #[tokio::main]
 async fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,8 +192,8 @@ fn set_up_helper_thread() {
 /// Wait for `SIGTERM`:
 ///
 /// ```rust,no_run
-/// # use signal_future::SignalFut;
-/// # use signal_future::Signal;
+/// # use signalfut::SignalFut;
+/// # use signalfut::Signal;
 /// #
 /// # async {
 /// let sigterm_fut = SignalFut::new(Signal::SIGTERM);


### PR DESCRIPTION
## What does this PR do

Rename crate to `signalfut` so that we can release it to crates.io (name signal_future has been taken)
