### PR TITLE
chore: use Nix from git

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ targets = [
 
 [dependencies]
 event-listener = "5.3.1"
-nix = { version = "0.29.0", features = ["signal", "fs"] }
+nix = { git = "https://github.com/nix-rust/nix", features = ["signal", "fs"] }
 once_cell = "1.19.0"
 pin-project = "1.1.5"
 

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -10,22 +10,20 @@ pub(crate) fn pipe() -> (OwnedFd, OwnedFd) {
 /// Return a pipe, with `O_CLOEXEC` set.
 #[cfg(target_os = "macos")]
 pub(crate) fn pipe() -> (OwnedFd, OwnedFd) {
-    use std::os::fd::AsRawFd;
-
     let (rx, tx) = nix::unistd::pipe().unwrap();
     let mut rx_flag = nix::fcntl::OFlag::from_bits(
-        nix::fcntl::fcntl(rx.as_raw_fd(), nix::fcntl::FcntlArg::F_GETFL).unwrap(),
+        nix::fcntl::fcntl(&rx, nix::fcntl::FcntlArg::F_GETFL).unwrap(),
     )
     .unwrap();
     rx_flag.insert(nix::fcntl::OFlag::O_CLOEXEC);
     let mut tx_flag = nix::fcntl::OFlag::from_bits(
-        nix::fcntl::fcntl(tx.as_raw_fd(), nix::fcntl::FcntlArg::F_GETFL).unwrap(),
+        nix::fcntl::fcntl(&tx, nix::fcntl::FcntlArg::F_GETFL).unwrap(),
     )
     .unwrap();
     tx_flag.insert(nix::fcntl::OFlag::O_CLOEXEC);
 
-    nix::fcntl::fcntl(rx.as_raw_fd(), nix::fcntl::FcntlArg::F_SETFL(rx_flag)).unwrap();
-    nix::fcntl::fcntl(tx.as_raw_fd(), nix::fcntl::FcntlArg::F_SETFL(tx_flag)).unwrap();
+    nix::fcntl::fcntl(&rx, nix::fcntl::FcntlArg::F_SETFL(rx_flag)).unwrap();
+    nix::fcntl::fcntl(&tx, nix::fcntl::FcntlArg::F_SETFL(tx_flag)).unwrap();
 
     (rx, tx)
 }


### PR DESCRIPTION
## What does this PR do

Use Nix from git, it has adopted I/O safety for module `unistd`, so finally, the interfaces of `read()` and `write()` are consistent now.